### PR TITLE
Add Changes file and record github repo in metadata and doc

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,0 +1,5 @@
+Revision history for Perl module YAHC
+
+0.013 2015-05-?? IKRUGLOV
+    - Added this Changes file
+

--- a/Changes
+++ b/Changes
@@ -1,5 +1,6 @@
 Revision history for Perl module YAHC
 
 0.013 2015-05-?? IKRUGLOV
+    - Added github repo to the dist metadata and the doc
     - Added this Changes file
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,4 +13,7 @@ requires       'Time::HiRes'                        => '0';
 
 #test_requires  'Test::More'     => '0.88';
 
+# metadata for the github repo
+repository 'https://github.com/ikruglov/YAHC';
+
 WriteAll;

--- a/lib/YAHC.pm
+++ b/lib/YAHC.pm
@@ -822,6 +822,10 @@ YAHC uses following state machines for every connection:
                   +-----------------+
 
 
+=head1 REPOSITORY
+
+L<https://github.com/ikruglov/YAHC>
+
 =head1 AUTHORS
 
 Ivan Kruglov <ivan.kruglov@yahoo.com>

--- a/lib/YAHC.pm
+++ b/lib/YAHC.pm
@@ -3,7 +3,7 @@ package YAHC;
 use strict;
 use warnings;
 
-our $VERSION = '0.012';
+our $VERSION = '0.013';
 
 use EV;
 use Time::HiRes;


### PR DESCRIPTION
Hi,

The main reason I did this PR was to add the github repo to the dist metadata and the doc. Having it in the metadata means it will be shown in the sidebar in MetaCPAN, and other tools will be able to find it automatically.

Cheers,
Neil
