### PR TITLE
Read only headers for a HEAD request

### DIFF
--- a/lib/YAHC.pm
+++ b/lib/YAHC.pm
@@ -731,6 +731,8 @@ sub _set_read_state {
                         return;
                     }
                 }
+            } elsif ($decapitated && ($conn->{request}{method} && $conn->{request}{method} eq 'HEAD')) {
+                _set_user_action_state($self, $conn_id); # We are done reading headers for a HEAD request
             } elsif ($decapitated && length($buf) >= $content_length) {
                 $conn->{response}{body} = (length($buf) > $content_length ? substr($buf, 0, $content_length) : $buf);
                 _set_user_action_state($self, $conn_id);


### PR DESCRIPTION
YAHC would wait indefinitely/until request_timeout for payload when
using the HEAD method instead of jumping to the USER ACTION state after
the headers have been successfully read.

The check for $conn->{request}{method} existence needed as the client
needn't provide a method (defaulting to GET when making the actual
HTTP request).