### PR TITLE
Support implicit content length through closed connection

### DIFF
--- a/lib/YAHC.pm
+++ b/lib/YAHC.pm
@@ -714,6 +714,10 @@ sub _set_read_state {
                     # No content length, use chunked transfer encoding instead
                 } elsif (exists $headers->{'Content-Length'}) { # 3.
                     $content_length = $headers->{'Content-Length'};
+                    if ($content_length !~ m#\A[0-9]+\z#) {
+                        _set_user_action_state($self, $conn_id, YAHC::Error::RESPONSE_ERROR(), "Not-numeric Content-Length received on the response");
+                        return;
+                    }
                 } else {
                     # byteranges (point .4 on the spec) not supported
                     $no_content_length = 1;

--- a/t/017_content_length.t
+++ b/t/017_content_length.t
@@ -1,0 +1,148 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More;
+use File::Temp ();
+use File::Temp qw/ :seekable /;
+use Data::Dumper;
+use YAHC qw/ yahc_conn_last_error /;
+use EV;
+
+my ($yahc, $yahc_storage) = YAHC->new;
+
+my $default_tests = sub {
+    my ($conn, $t) = @_;
+    my $response = $conn->{response};
+
+    is $response->{proto}, $t->{proto}, "$t->{name} - Protocol match";
+    is $response->{status}, $t->{status}, "$t->{name} - Status code";
+    is_deeply $response->{head}, $t->{headers}, "$t->{name} - Headers";
+    is $response->{body}, $t->{body}, "$t->{name} - Body/content";
+};
+
+my @TESTS = (
+    {
+        name => "Simple request with content-length",
+        proto => 'HTTP/1.1',
+        status => '200',
+        status_msg => 'OK',
+        headers => {
+            'Server' => 'mock',
+            'Content-Type' => 'text/plain',
+            'Content-Length' => '230',
+        },
+        body => 'a' x 230,
+        tests => $default_tests,
+    },
+    {
+        name => "Simple request with smaller content-length",
+        proto => 'HTTP/1.1',
+        status => '200',
+        status_msg => 'OK',
+        headers => {
+            'Server' => 'mock',
+            'Content-Type' => 'text/plain',
+            'Content-Length' => '220',
+        },
+        body => 'a' x 230,
+        tests => sub {
+            my ($conn, $t) = @_;
+            my $response = $conn->{response};
+
+            is $response->{proto}, $t->{proto}, "$t->{name} - Protocol match";
+            is $response->{status}, $t->{status}, "$t->{name} - Status code";
+            is_deeply $response->{head}, $t->{headers}, "$t->{name} - Headers";
+            is $response->{body}, 'a' x 220, "$t->{name} - Body/content";
+        },
+    },
+    {
+        name => "Simple request without content-length",
+        proto => 'HTTP/1.1',
+        status => '200',
+        status_msg => 'OK',
+        headers => {
+            'Server' => 'mock',
+            'Content-Type' => 'text/plain',
+        },
+        body => 'a' x 230,
+        tests => $default_tests,
+    },
+    {
+        name => "Big request without content-length",
+        proto => 'HTTP/1.1',
+        status => '200',
+        status_msg => 'OK',
+        headers => {
+            'Server' => 'mock',
+            'Content-Type' => 'text/plain',
+        },
+        body => 'big' x 23000,
+        tests => $default_tests,
+    },
+    {
+        name => "Request with a non-numeric content length",
+        proto => 'HTTP/1.1',
+        status => '200',
+        status_msg => 'OK',
+        headers => {
+            'Server' => 'mock',
+            'Content-Type' => 'text/plain',
+            'Content-Length' => 'fourty-two',
+        },
+        body => 'a' x 42,
+        tests => sub {
+            my ($conn, $t) = @_;
+            my $response = $conn->{response};
+
+            is $response->{proto}, $t->{proto}, "$t->{name} - Protocol match";
+            is $response->{status}, $t->{status}, "$t->{name} - Status code";
+            is_deeply $response->{head}, $t->{headers}, "$t->{name} - Headers";
+            is $response->{body}, undef, "$t->{name} - Body/content (undef)";
+
+            my ($err, $msg) = yahc_conn_last_error($conn);
+            cmp_ok($err & YAHC::Error::RESPONSE_ERROR(), '==', YAHC::Error::RESPONSE_ERROR(), "$t->{name} - We got response error");
+        },
+    },
+);
+
+
+foreach my $t (@TESTS) {
+    my $conn = $yahc->request({
+        host => 'DUMMY',
+        keep_timeline => 1,
+        _test => 1,
+    });
+
+    my $f = File::Temp->new();
+    my $fh= do {
+        local $/ = undef;
+
+        my $msg = join(
+            "\x0d\x0a",
+            join( " ", $t->{proto}, $t->{status}, $t->{status_msg} ),
+            ( map "$_: $t->{headers}{$_}", keys %{ $t->{headers} } ),
+            '',
+            $t->{body}
+        );
+        print $f $msg;
+        $f->flush;
+        $f->seek(0, 0);
+        $f;
+    };
+
+    $yahc->{watchers}{$conn->{id}} = {
+        _fh => $fh,
+        io  => $yahc->loop->io($fh, EV::READ, sub {})
+    };
+
+    $conn->{state} = YAHC::State::CONNECTED();
+    $yahc->_set_read_state($conn->{id});
+    $yahc->run;
+
+    ok($conn->{state} == YAHC::State::COMPLETED(), "$t->{name} - YAHC state == completed")
+        or diag("got:\n" . YAHC::_strstate($conn->{state}) . "\nexpected:\nSTATE_COMPLETED\ntimeline: " . Dumper($conn->{timeline}));
+
+    $t->{tests}->($conn, $t);
+}
+
+done_testing;


### PR DESCRIPTION
This pull request attempts to add support for responses missing a Content-Length header (and not chunked), where the response body length is determined by the server closing the connection at the end of the request.

There's also the commit that adds validation for the Content-Length value, sorry for mixing into the same PR, made conflicts easier at this point.

The last commit also adds a test file for these cases.. it could sure use some improvement, but so far travis seems not to complain about them.